### PR TITLE
Added Module Name & Ops Request and Removed Cancel Meeting

### DIFF
--- a/one-to-one-scheduler/one-to-one-scheduler.gs
+++ b/one-to-one-scheduler/one-to-one-scheduler.gs
@@ -678,7 +678,7 @@ function cancelEvents() {
   for (let i = 0; i < canceledRows.length; ++i) {
     summary += `\nRow ${canceledRows[i]}`;
   }
-  summary += `---
+  summary += `\n---
   Following rows have invalid meeting id.
   `;
   for (let i = 0; i < invalidMeetings.length; ++i) {

--- a/one-to-one-scheduler/one-to-one-scheduler.gs
+++ b/one-to-one-scheduler/one-to-one-scheduler.gs
@@ -64,7 +64,6 @@ const MSG_HELP = `
 10. SSM emails - Additional emails you want to include in the meeting - Comma separated values.
 11. Mentor email - Email id of the mentor. To be filled by the team.
 12. Mentor response - Auto populated by the script.
-13. Cancel meeting - 1 or 0. 1 means cancel. To be filled by the team.
 `;
 
 const DATE_DELIMITER = "-";


### PR DESCRIPTION
- Added "Module Name" Column at the start

- Added "Ops Request" Column before "SSMs emails" Column

- Removed "Cancel Meeting" Column

- Module Name will now come in the Meet Name.

- If Ops Request = 0, It means Ignore the Row

- If Ops Request = 2, It means Consider the Row for Invites

- If Ops Request = 2, It means Cancel Meeting

- "Help" menu Updated

- Version Number updated from 4 to 5